### PR TITLE
fix nil windows

### DIFF
--- a/Sources/SwiftyFitsize/SwiftyFitsizeConfig.swift
+++ b/Sources/SwiftyFitsize/SwiftyFitsizeConfig.swift
@@ -40,15 +40,18 @@ extension SwiftyFitsize {
             public static let isIphneXSeries = isIPhoneXSeries()
             
             public static func getCurrentWindow() -> UIWindow? {
-                if let window = UIApplication.shared.delegate?.window {
-                    return window
-                }
-                if #available(iOS 13.0, *) {
-                    if let window = (UIApplication.shared.connectedScenes.first as? UIWindowScene)?.windows.first {
-                        return window
-                    }
-                }
-                return UIApplication.shared.keyWindow
+              if let applicationWindow = UIApplication.shared.delegate?.window ?? nil {
+                  return applicationWindow
+              }
+              if #available(iOS 13.0, *) {
+                  if let scene = UIApplication.shared.connectedScenes.first(where: { $0.session.role == .windowApplication }),
+                     let sceneDelegate = scene.delegate as? UIWindowSceneDelegate,
+                     let window = sceneDelegate.window as? UIWindow
+                  {
+                      return window
+                  }
+              }
+              return UIApplication.shared.keyWindow
             }
             
             /// 是否是iphoneX系列


### PR DESCRIPTION
1、即使 UIApplication.shared.delegate?.window 为 nil，整个 if let条件依然成立，会进入 if块，但绑定到的 window是 nil，导致后续使用崩溃
2、 使用了系统的官方接口 (UIWindowSceneDelegate) 来确定哪个窗口是这个场景的主要展示窗口