### PR TITLE
Fix operator overload ambiguity on Xcode 26.4

### DIFF
--- a/Sources/SwiftyFitsize/SwiftyFitsize.swift
+++ b/Sources/SwiftyFitsize/SwiftyFitsize.swift
@@ -296,6 +296,9 @@ public postfix func ~ (value: Int) -> CGFloat {
 public postfix func ~ (value: Float) -> CGFloat {
     return CGFloat(value).sf(.flexibleWidth)
 }
+public postfix func ~ (value: Double) -> CGFloat {
+    return CGFloat(value).sf(.flexibleWidth)
+}
 public postfix func ~ (value: CGPoint) -> CGPoint {
     return value.sf(.flexibleWidth)
 }
@@ -321,6 +324,9 @@ public postfix func ≈ (value: Int) -> CGFloat {
     return CGFloat(value).sf(.forceWidth)
 }
 public postfix func ≈ (value: Float) -> CGFloat {
+    return CGFloat(value).sf(.forceWidth)
+}
+public postfix func ≈ (value: Double) -> CGFloat {
     return CGFloat(value).sf(.forceWidth)
 }
 public postfix func ≈ (value: CGPoint) -> CGPoint {
@@ -350,6 +356,9 @@ public postfix func ∣ (value: Int) -> CGFloat {
 public postfix func ∣ (value: Float) -> CGFloat {
     return CGFloat(value).sf(.flexibleHeight)
 }
+public postfix func ∣ (value: Double) -> CGFloat {
+    return CGFloat(value).sf(.flexibleHeight)
+}
 public postfix func ∣ (value: CGPoint) -> CGPoint {
     return value.sf(.flexibleHeight)
 }
@@ -375,6 +384,9 @@ public postfix func ∥ (value: Int) -> CGFloat {
     return CGFloat(value).sf(.forceHeight)
 }
 public postfix func ∥ (value: Float) -> CGFloat {
+    return CGFloat(value).sf(.forceHeight)
+}
+public postfix func ∥ (value: Double) -> CGFloat {
     return CGFloat(value).sf(.forceHeight)
 }
 public postfix func ∥ (value: CGPoint) -> CGPoint {
@@ -404,6 +416,9 @@ public postfix func ∣= (value: Int) -> CGFloat {
 public postfix func ∣= (value: Float) -> CGFloat {
     return CGFloat(value).sf(.flexibleSafeAreaCenterHeight)
 }
+public postfix func ∣= (value: Double) -> CGFloat {
+    return CGFloat(value).sf(.flexibleSafeAreaCenterHeight)
+}
 public postfix func ∣= (value: CGPoint) -> CGPoint {
     return value.sf(.flexibleSafeAreaCenterHeight)
 }
@@ -429,6 +444,9 @@ public postfix func ∥= (value: Int) -> CGFloat {
     return CGFloat(value).sf(.forceSafeAreaCenterHeight)
 }
 public postfix func ∥= (value: Float) -> CGFloat {
+    return CGFloat(value).sf(.forceSafeAreaCenterHeight)
+}
+public postfix func ∥= (value: Double) -> CGFloat {
     return CGFloat(value).sf(.forceSafeAreaCenterHeight)
 }
 public postfix func ∥= (value: CGPoint) -> CGPoint {
@@ -458,6 +476,9 @@ public postfix func ∣- (value: Int) -> CGFloat {
 public postfix func ∣- (value: Float) -> CGFloat {
     return CGFloat(value).sf(.flexibleSafeAreaWithoutTopHeight)
 }
+public postfix func ∣- (value: Double) -> CGFloat {
+    return CGFloat(value).sf(.flexibleSafeAreaWithoutTopHeight)
+}
 public postfix func ∣- (value: CGPoint) -> CGPoint {
     return value.sf(.flexibleSafeAreaWithoutTopHeight)
 }
@@ -483,6 +504,9 @@ public postfix func ∥- (value: Int) -> CGFloat {
     return CGFloat(value).sf(.forceSafeAreaWithoutTopHeight)
 }
 public postfix func ∥- (value: Float) -> CGFloat {
+    return CGFloat(value).sf(.forceSafeAreaWithoutTopHeight)
+}
+public postfix func ∥- (value: Double) -> CGFloat {
     return CGFloat(value).sf(.forceSafeAreaWithoutTopHeight)
 }
 public postfix func ∥- (value: CGPoint) -> CGPoint {


### PR DESCRIPTION
### 問題

在 Xcode 26.4 之後，對「浮點字面量」使用 SwiftyFitsize 的後綴適配運算子會報錯：

```swift
make.left.equalTo(view5).offset(-0.5~)   // ❌ Ambiguous use of operator '~'
```

原因：由於「浮點字面量」的預設型別是 Double，當寫出 0.5~ 時，編譯器在 Float 與 CGFloat 之間沒有偏好依據，於是回報 `Ambiguous use of operator '~'`。

### 解法
適配運算子補上 Double 多載，浮點數會優先選用「預設型別 = Double」這組多載，歧義即消失，且寫法皆無需調整。